### PR TITLE
Issue viewport navigation with lags

### DIFF
--- a/Sources/AwesomeBump.pro
+++ b/Sources/AwesomeBump.pro
@@ -17,7 +17,8 @@ HEADERS       = glwidget.h \
     formsettingsfield.h \
     formsettingscontainer.h \
     utils/qglbuffers.h \
-    dialoglogger.h
+    dialoglogger.h \
+    glwidgetbase.h
 
 SOURCES       = glwidget.cpp \
                 main.cpp \
@@ -32,7 +33,8 @@ SOURCES       = glwidget.cpp \
     formsettingsfield.cpp \
     formsettingscontainer.cpp \
     utils/qglbuffers.cpp \
-    dialoglogger.cpp
+    dialoglogger.cpp \
+    glwidgetbase.cpp
 
 
 # install

--- a/Sources/glimageeditor.cpp
+++ b/Sources/glimageeditor.cpp
@@ -42,7 +42,7 @@
 
 
 GLImage::GLImage(QWidget *parent)
-    : QGLWidget(QGLFormat::defaultFormat(), parent)
+    : GLWidgetBase(QGLFormat::defaultFormat(), parent)
 
 {
     bShadowRender         = false;

--- a/Sources/glimageeditor.cpp
+++ b/Sources/glimageeditor.cpp
@@ -2153,9 +2153,9 @@ void GLImage::wheelEvent(QWheelEvent *event){
     updateGL();
 }
 
-void GLImage::relativeMouseMoveEvent(int dx, int dy, bool* wrapMouse, QMouseEvent *event)
+void GLImage::relativeMouseMoveEvent(int dx, int dy, bool* wrapMouse, Qt::MouseButtons buttons)
 {
-    if(activeImage->imageType == OCCLUSION_TEXTURE && event->buttons() & Qt::LeftButton){
+    if(activeImage->imageType == OCCLUSION_TEXTURE && buttons & Qt::LeftButton){
         QMessageBox msgBox;
         msgBox.setText("Warning!");
         msgBox.setInformativeText("Sorry, but you cannot modify UV's mapping of occlusion texture. Try Diffuse or height texture.");
@@ -2163,7 +2163,7 @@ void GLImage::relativeMouseMoveEvent(int dx, int dy, bool* wrapMouse, QMouseEven
         msgBox.exec();
         return;
     }
-    if(activeImage->imageType == NORMAL_TEXTURE && (event->buttons() & Qt::LeftButton)){
+    if(activeImage->imageType == NORMAL_TEXTURE && (buttons & Qt::LeftButton)){
         QMessageBox msgBox;
         msgBox.setText("Warning!");
         msgBox.setInformativeText("Sorry, but you cannot modify UV's mapping of normal texture. Try Diffuse or height texture.");
@@ -2171,7 +2171,7 @@ void GLImage::relativeMouseMoveEvent(int dx, int dy, bool* wrapMouse, QMouseEven
         msgBox.exec();
         return;
     }
-    if(activeImage->imageType == METALLIC_TEXTURE && (event->buttons() & Qt::LeftButton)){
+    if(activeImage->imageType == METALLIC_TEXTURE && (buttons & Qt::LeftButton)){
         QMessageBox msgBox;
         msgBox.setText("Warning!");
         msgBox.setInformativeText("Sorry, but you cannot modify UV's mapping of metallic texture. Try Diffuse or height texture.");
@@ -2180,7 +2180,7 @@ void GLImage::relativeMouseMoveEvent(int dx, int dy, bool* wrapMouse, QMouseEven
         return;
     }
 
-    if(activeImage->imageType == ROUGHNESS_TEXTURE && (event->buttons() & Qt::LeftButton)){
+    if(activeImage->imageType == ROUGHNESS_TEXTURE && (buttons & Qt::LeftButton)){
         QMessageBox msgBox;
         msgBox.setText("Warning!");
         msgBox.setInformativeText("Sorry, but you cannot modify UV's mapping of roughness texture. Try Diffuse or height texture.");
@@ -2188,7 +2188,7 @@ void GLImage::relativeMouseMoveEvent(int dx, int dy, bool* wrapMouse, QMouseEven
         msgBox.exec();
         return;
     }
-    if(activeImage->imageType == SPECULAR_TEXTURE && (event->buttons() & Qt::LeftButton)){
+    if(activeImage->imageType == SPECULAR_TEXTURE && (buttons & Qt::LeftButton)){
         QMessageBox msgBox;
         msgBox.setText("Warning!");
         msgBox.setInformativeText("Sorry, but you cannot modify UV's mapping of specular texture. Try Diffuse or height texture.");
@@ -2208,7 +2208,7 @@ void GLImage::relativeMouseMoveEvent(int dx, int dy, bool* wrapMouse, QMouseEven
     switch(uvManilupationMethod){
         // translate UV coordinates
         case(UV_TRANSLATE):
-            if(event->buttons() & Qt::LeftButton){ // drag image
+            if(buttons & Qt::LeftButton){ // drag image
                 setCursor(Qt::SizeAllCursor);
                 // move all corners
                 QVector2D averagePos(0.0,0.0);
@@ -2231,7 +2231,7 @@ void GLImage::relativeMouseMoveEvent(int dx, int dy, bool* wrapMouse, QMouseEven
                 }
             }
             }// end if dragging
-            if(event->buttons() & Qt::LeftButton){
+            if(buttons & Qt::LeftButton){
             // calculate distance from corners
             if(draggingCorner == -1){
             for(int i = 0; i < 4 ; i++){
@@ -2247,7 +2247,7 @@ void GLImage::relativeMouseMoveEvent(int dx, int dy, bool* wrapMouse, QMouseEven
         break;
         case(UV_SCALE_XY):
             setCursor(Qt::OpenHandCursor);
-            if(event->buttons() & Qt::LeftButton){ // drag image
+            if(buttons & Qt::LeftButton){ // drag image
                 setCursor(Qt::SizeAllCursor);
                 QVector2D dmouse = QVector2D(-dx*(float(orthographicProjWidth)/width()),dy*(float(orthographicProjHeight)/height()));
                 cornerWeights.setX(cornerWeights.x()-dmouse.x());
@@ -2261,14 +2261,14 @@ void GLImage::relativeMouseMoveEvent(int dx, int dy, bool* wrapMouse, QMouseEven
 
 
 
-    if (event->buttons() & Qt::RightButton){
+    if (buttons & Qt::RightButton){
         xTranslation += dx*(float(orthographicProjWidth)/width());
         yTranslation -= dy*(float(orthographicProjHeight)/height());
         setCursor(Qt::ClosedHandCursor);
     }
 
     // mouse looping in 2D view window
-    *wrapMouse = (event->buttons() & Qt::RightButton || event->buttons() & Qt::LeftButton );
+    *wrapMouse = (buttons & Qt::RightButton || buttons & Qt::LeftButton );
 
 
     updateMousePosition();

--- a/Sources/glimageeditor.cpp
+++ b/Sources/glimageeditor.cpp
@@ -2154,7 +2154,7 @@ void GLImage::wheelEvent(QWheelEvent *event){
     updateGL();
 }
 
-void GLImage::relativeMouseMoveEvent(int dx, int dy, bool* bMouseDragged, QMouseEvent *event)
+void GLImage::relativeMouseMoveEvent(int dx, int dy, bool* wrapMouse, QMouseEvent *event)
 {
     if(activeImage->imageType == OCCLUSION_TEXTURE && event->buttons() & Qt::LeftButton){
         QMessageBox msgBox;
@@ -2269,7 +2269,7 @@ void GLImage::relativeMouseMoveEvent(int dx, int dy, bool* bMouseDragged, QMouse
     }
 
     // mouse looping in 2D view window
-    *bMouseDragged = (event->buttons() & Qt::RightButton || event->buttons() & Qt::LeftButton );
+    *wrapMouse = (event->buttons() & Qt::RightButton || event->buttons() & Qt::LeftButton );
 
 
     updateMousePosition();

--- a/Sources/glimageeditor.cpp
+++ b/Sources/glimageeditor.cpp
@@ -2154,7 +2154,7 @@ void GLImage::wheelEvent(QWheelEvent *event){
     updateGL();
 }
 
-void GLImage::mouseMoveEvent(QMouseEvent *event)
+void GLImage::relativeMouseMoveEvent(int dx, int dy, bool* bMouseDragged, QMouseEvent *event)
 {
     if(activeImage->imageType == OCCLUSION_TEXTURE && event->buttons() & Qt::LeftButton){
         QMessageBox msgBox;
@@ -2197,10 +2197,6 @@ void GLImage::mouseMoveEvent(QMouseEvent *event)
         msgBox.exec();
         return;
     }
-
-    int dx = event->x() - lastCursorPos.x();
-    int dy = event->y() - lastCursorPos.y();
-    lastCursorPos = event->pos();
 
     QVector2D defCorners[4];//default position of corners
     defCorners[0] = QVector2D(0,0) ;
@@ -2273,24 +2269,7 @@ void GLImage::mouseMoveEvent(QMouseEvent *event)
     }
 
     // mouse looping in 2D view window
-    if (event->buttons() & Qt::RightButton || event->buttons() & Qt::LeftButton ){
-        if(event->x() > width()-10){
-            lastCursorPos.setX(10);
-        }
-        if(event->x() < 10){
-            lastCursorPos.setX(width()-10);
-        }
-        if(event->y() > height()-10){
-            lastCursorPos.setY(10);
-        }
-        if(event->y() < 10){
-            lastCursorPos.setY(height()-10);
-        }
-
-        QCursor c = cursor();
-        c.setPos(mapToGlobal(lastCursorPos));
-        setCursor(c);
-    }
+    *bMouseDragged = (event->buttons() & Qt::RightButton || event->buttons() & Qt::LeftButton );
 
 
     updateMousePosition();
@@ -2302,8 +2281,8 @@ void GLImage::mouseMoveEvent(QMouseEvent *event)
 }
 void GLImage::mousePressEvent(QMouseEvent *event)
 {
+    GLWidgetBase::mousePressEvent(event);
 
-    lastCursorPos = event->pos();
     bSkipProcessing = true;
     draggingCorner = -1;
     // change cursor

--- a/Sources/glimageeditor.cpp
+++ b/Sources/glimageeditor.cpp
@@ -65,7 +65,6 @@ GLImage::GLImage(QWidget *parent)
     cornerCursors[1] = QCursor(QPixmap(":/resources/corner2.png"));
     cornerCursors[2] = QCursor(QPixmap(":/resources/corner3.png"));
     cornerCursors[3] = QCursor(QPixmap(":/resources/corner4.png"));
-    setMouseTracking(true);
 }
 
 GLImage::~GLImage()

--- a/Sources/glimageeditor.h
+++ b/Sources/glimageeditor.h
@@ -97,7 +97,7 @@ signals:
 protected:
     void mousePressEvent(QMouseEvent *event);
     void mouseReleaseEvent(QMouseEvent *event);
-    void relativeMouseMoveEvent(int dx, int dy, bool *wrapMouse, QMouseEvent *event);
+    void relativeMouseMoveEvent(int dx, int dy, bool *wrapMouse, Qt::MouseButtons buttons);
     void wheelEvent(QWheelEvent *event);
     void updateMousePosition();
     void showEvent(QShowEvent* event);

--- a/Sources/glimageeditor.h
+++ b/Sources/glimageeditor.h
@@ -97,7 +97,7 @@ signals:
 protected:
     void mousePressEvent(QMouseEvent *event);
     void mouseReleaseEvent(QMouseEvent *event);
-    void relativeMouseMoveEvent(int dx, int dy, bool *bMouseDragged, QMouseEvent *event);
+    void relativeMouseMoveEvent(int dx, int dy, bool *wrapMouse, QMouseEvent *event);
     void wheelEvent(QWheelEvent *event);
     void updateMousePosition();
     void showEvent(QShowEvent* event);

--- a/Sources/glimageeditor.h
+++ b/Sources/glimageeditor.h
@@ -42,9 +42,10 @@
 ****************************************************************************/
 
 #include <QWidget>
-#include <QGLWidget>
 #include <QtOpenGL>
 #include <QOpenGLFunctions_4_0_Core>
+
+#include "glwidgetbase.h"
 
 #include <math.h>
 #include <map>
@@ -54,7 +55,7 @@ QT_FORWARD_DECLARE_CLASS(QOpenGLShaderProgram);
 
 
 //! [0]
-class GLImage : public QGLWidget , protected QOpenGLFunctions_4_0_Core
+class GLImage : public GLWidgetBase , protected QOpenGLFunctions_4_0_Core
 {
     Q_OBJECT
 

--- a/Sources/glimageeditor.h
+++ b/Sources/glimageeditor.h
@@ -97,7 +97,7 @@ signals:
 protected:
     void mousePressEvent(QMouseEvent *event);
     void mouseReleaseEvent(QMouseEvent *event);
-    void mouseMoveEvent(QMouseEvent *event);
+    void relativeMouseMoveEvent(int dx, int dy, bool *bMouseDragged, QMouseEvent *event);
     void wheelEvent(QWheelEvent *event);
     void updateMousePosition();
     void showEvent(QShowEvent* event);
@@ -242,7 +242,6 @@ private:
     bool bSkipProcessing;   // draw quad but skip all the processing step (using during mouse interaction)
     float windowRatio;      // window width-height ratio
     float fboRatio;         // active fbo width-height ratio
-    QPoint lastCursorPos;
 
     // Image resize
     int resize_width;

--- a/Sources/glwidget.cpp
+++ b/Sources/glwidget.cpp
@@ -643,7 +643,7 @@ int GLWidget::glhUnProjectf(float& winx, float& winy, float& winz,
       return 1;
   }
 
-void GLWidget::relativeMouseMoveEvent(int dx, int dy, bool* bMouseDragged, QMouseEvent *event)
+void GLWidget::relativeMouseMoveEvent(int dx, int dy, bool* wrapMouse, QMouseEvent *event)
 {
     if ((event->buttons() & Qt::LeftButton) && (event->buttons() & Qt::RightButton)) {
 
@@ -660,7 +660,7 @@ void GLWidget::relativeMouseMoveEvent(int dx, int dy, bool* bMouseDragged, QMous
         if(lightPosition.y() < -10.0) lightPosition.setY(-10.0);
         lightDirection.rotateView(-2*dx/1.0,2*dy/1.0);
     }else{
-        *bMouseDragged = false;
+        *wrapMouse = false;
     }
 }
 //! [10]

--- a/Sources/glwidget.cpp
+++ b/Sources/glwidget.cpp
@@ -67,7 +67,6 @@ GLWidget::GLWidget(QWidget *parent, QGLWidget * shareWidget)
     lightRadius             = 0.1;
     m_env_map               = NULL;
 
-    setMouseTracking(true);
     setCursor(Qt::PointingHandCursor);
     lightCursor = QCursor(QPixmap(":/resources/lightCursor.png"));
 

--- a/Sources/glwidget.cpp
+++ b/Sources/glwidget.cpp
@@ -642,15 +642,15 @@ int GLWidget::glhUnProjectf(float& winx, float& winy, float& winz,
       return 1;
   }
 
-void GLWidget::relativeMouseMoveEvent(int dx, int dy, bool* wrapMouse, QMouseEvent *event)
+void GLWidget::relativeMouseMoveEvent(int dx, int dy, bool* wrapMouse, Qt::MouseButtons buttons)
 {
-    if ((event->buttons() & Qt::LeftButton) && (event->buttons() & Qt::RightButton)) {
+    if ((buttons & Qt::LeftButton) && (buttons & Qt::RightButton)) {
 
-    }else if (event->buttons() & Qt::LeftButton) {
+    }else if (buttons & Qt::LeftButton) {
         camera.rotateView(dx/1.0,dy/1.0);
-    } else if (event->buttons() & Qt::RightButton) {
+    } else if (buttons & Qt::RightButton) {
         camera.position +=QVector3D(dx/500.0,dy/500.0,0)*camera.radius;
-    } else if (event->buttons() & Qt::MiddleButton) {
+    } else if (buttons & Qt::MiddleButton) {
 
         lightPosition += QVector4D(0.05*dx,-0.05*dy,-0,0);
         if(lightPosition.x() > +10.0) lightPosition.setX(+10.0);

--- a/Sources/glwidget.cpp
+++ b/Sources/glwidget.cpp
@@ -45,7 +45,7 @@
 QDir* GLWidget::recentMeshDir = NULL;
 
 GLWidget::GLWidget(QWidget *parent, QGLWidget * shareWidget)
-    : QGLWidget(QGLFormat::defaultFormat(), parent, shareWidget)
+    : GLWidgetBase(QGLFormat::defaultFormat(), parent, shareWidget)
 {
     zoom                    = 60;
     lightPosition           = QVector4D(0,0,5.0,1);

--- a/Sources/glwidget.cpp
+++ b/Sources/glwidget.cpp
@@ -595,7 +595,8 @@ void GLWidget::resizeGL(int width, int height)
 
 void GLWidget::mousePressEvent(QMouseEvent *event)
 {
-    lastPos = event->pos();
+    GLWidgetBase::mousePressEvent(event);
+
     setCursor(Qt::ClosedHandCursor);
     if (event->buttons() & Qt::RightButton) {
         setCursor(Qt::SizeAllCursor);
@@ -642,12 +643,8 @@ int GLWidget::glhUnProjectf(float& winx, float& winy, float& winz,
       return 1;
   }
 
-void GLWidget::mouseMoveEvent(QMouseEvent *event)
+void GLWidget::relativeMouseMoveEvent(int dx, int dy, bool* bMouseDragged, QMouseEvent *event)
 {
-
-    int dx = event->x() - lastPos.x();
-    int dy = event->y() - lastPos.y();
-    bool bMouseDragged = true;
     if ((event->buttons() & Qt::LeftButton) && (event->buttons() & Qt::RightButton)) {
 
     }else if (event->buttons() & Qt::LeftButton) {
@@ -663,35 +660,8 @@ void GLWidget::mouseMoveEvent(QMouseEvent *event)
         if(lightPosition.y() < -10.0) lightPosition.setY(-10.0);
         lightDirection.rotateView(-2*dx/1.0,2*dy/1.0);
     }else{
-        bMouseDragged = false;
+        *bMouseDragged = false;
     }
-
-    lastPos = event->pos();
-    // mouse looping in 3D view window
-    if(bMouseDragged){        
-        if(event->x() > width()-10){
-            lastPos.setX(10);
-        }
-        if(event->x() < 10){
-            lastPos.setX(width()-10);
-        }
-
-        if(event->y() > height()-10){
-            lastPos.setY(10);
-        }
-        if(event->y() < 10){
-            lastPos.setY(height()-10);
-        }
-
-        QCursor c = cursor();
-        c.setPos(mapToGlobal(lastPos));
-        setCursor(c);
-
-        updateGL();
-    }
-
-
-
 }
 //! [10]
 

--- a/Sources/glwidget.h
+++ b/Sources/glwidget.h
@@ -112,7 +112,7 @@ protected:
     
     void mousePressEvent(QMouseEvent *event);
     void mouseReleaseEvent(QMouseEvent *event);
-    void relativeMouseMoveEvent(int dx, int dy, bool *bMouseDragged, QMouseEvent *event);
+    void relativeMouseMoveEvent(int dx, int dy, bool *wrapMouse, QMouseEvent *event);
     void wheelEvent(QWheelEvent *event);
 
 

--- a/Sources/glwidget.h
+++ b/Sources/glwidget.h
@@ -112,7 +112,7 @@ protected:
     
     void mousePressEvent(QMouseEvent *event);
     void mouseReleaseEvent(QMouseEvent *event);
-    void mouseMoveEvent(QMouseEvent *event);
+    void relativeMouseMoveEvent(int dx, int dy, bool *bMouseDragged, QMouseEvent *event);
     void wheelEvent(QWheelEvent *event);
 
 
@@ -165,7 +165,6 @@ private:
     QVector4D cursorPositionOnPlane;
     float ratio;
     float zoom;
-    QPoint lastPos;    
     AwesomeCamera camera;   // light used for standard phong shading
     AwesomeCamera lightDirection;//second light - use camera class to rotate light
     QCursor lightCursor;

--- a/Sources/glwidget.h
+++ b/Sources/glwidget.h
@@ -112,7 +112,7 @@ protected:
     
     void mousePressEvent(QMouseEvent *event);
     void mouseReleaseEvent(QMouseEvent *event);
-    void relativeMouseMoveEvent(int dx, int dy, bool *wrapMouse, QMouseEvent *event);
+    void relativeMouseMoveEvent(int dx, int dy, bool *wrapMouse, Qt::MouseButtons buttons);
     void wheelEvent(QWheelEvent *event);
 
 

--- a/Sources/glwidget.h
+++ b/Sources/glwidget.h
@@ -49,13 +49,14 @@
 #include "camera.h"
 #include "utils/Mesh.hpp"
 #include "utils/qglbuffers.h"
+#include "glwidgetbase.h"
 #include "glimageeditor.h"
 #include <QOpenGLFunctions_4_0_Core>
 
 QT_FORWARD_DECLARE_CLASS(QOpenGLShaderProgram);
 
 
-class GLWidget : public QGLWidget , protected QOpenGLFunctions_4_0_Core
+class GLWidget : public GLWidgetBase , protected QOpenGLFunctions_4_0_Core
 {
     Q_OBJECT
 

--- a/Sources/glwidgetbase.cpp
+++ b/Sources/glwidgetbase.cpp
@@ -8,6 +8,7 @@ GLWidgetBase::GLWidgetBase(const QGLFormat& format, QWidget *parent, QGLWidget *
       eventLoopStarted(false)
 {
     connect(this, &GLWidgetBase::updateGLLater, this, &GLWidgetBase::updateGLNow, Qt::QueuedConnection);
+    setMouseTracking(true);
 }
 
 GLWidgetBase::~GLWidgetBase()

--- a/Sources/glwidgetbase.cpp
+++ b/Sources/glwidgetbase.cpp
@@ -4,7 +4,8 @@
 
 GLWidgetBase::GLWidgetBase(const QGLFormat& format, QWidget *parent, QGLWidget * shareWidget)
     : QGLWidget(format, parent, shareWidget),
-      updateIsQueued(false)
+      updateIsQueued(false),
+      eventLoopStarted(false)
 {
     connect(this, &GLWidgetBase::updateGLLater, this, &GLWidgetBase::updateGLNow, Qt::QueuedConnection);
 }
@@ -30,6 +31,13 @@ void GLWidgetBase::updateGL()
         updateIsQueued = true;
         updateGLLater();
     }
+
+    // Workaround: When the viewport gets drawn for the first time, the rendering
+    // has to be done multiple times for the end result to look correct.
+    // This workaround passes every drawcall, until mouse events are received for
+    // the first time.
+    if(!eventLoopStarted)
+        updateGLNow();
 }
 
 void GLWidgetBase::mousePressEvent(QMouseEvent *event)
@@ -71,4 +79,6 @@ void GLWidgetBase::mouseMoveEvent(QMouseEvent *event)
 
         updateGL();
     }
+
+    eventLoopStarted = true;
 }

--- a/Sources/glwidgetbase.cpp
+++ b/Sources/glwidgetbase.cpp
@@ -1,11 +1,13 @@
 #include "glwidgetbase.h"
 #include <QThread>
+#include <QMouseEvent>
 
 GLWidgetBase::GLWidgetBase(const QGLFormat& format, QWidget *parent, QGLWidget * shareWidget)
     : QGLWidget(format, parent, shareWidget),
       updateIsQueued(false)
 {
     connect(this, &GLWidgetBase::updateGLLater, this, &GLWidgetBase::updateGLNow, Qt::QueuedConnection);
+    startTimer(0, Qt::VeryCoarseTimer);
 }
 
 GLWidgetBase::~GLWidgetBase()
@@ -28,5 +30,44 @@ void GLWidgetBase::updateGL()
         // Queue the updating the OpenGL Widget
         updateIsQueued = true;
         updateGLLater();
+    }
+}
+
+void GLWidgetBase::mousePressEvent(QMouseEvent *event)
+{
+    lastCursorPos = event->pos();
+}
+
+void GLWidgetBase::mouseMoveEvent(QMouseEvent *event)
+{
+    int dx = event->x() - lastCursorPos.x();
+    int dy = event->y() - lastCursorPos.y();
+    bool bMouseDragged = true;
+
+    relativeMouseMoveEvent(dx, dy, &bMouseDragged, event);
+
+    lastCursorPos = event->pos();
+    // mouse looping in view window
+
+    if(bMouseDragged){
+        if(event->x() > width()-10){
+            lastCursorPos.setX(10);
+        }
+        if(event->x() < 10){
+            lastCursorPos.setX(width()-10);
+        }
+
+        if(event->y() > height()-10){
+            lastCursorPos.setY(10);
+        }
+        if(event->y() < 10){
+            lastCursorPos.setY(height()-10);
+        }
+
+        QCursor c = cursor();
+        c.setPos(mapToGlobal(lastCursorPos));
+        setCursor(c);
+
+        updateGL();
     }
 }

--- a/Sources/glwidgetbase.cpp
+++ b/Sources/glwidgetbase.cpp
@@ -1,0 +1,32 @@
+#include "glwidgetbase.h"
+#include <QThread>
+
+GLWidgetBase::GLWidgetBase(const QGLFormat& format, QWidget *parent, QGLWidget * shareWidget)
+    : QGLWidget(format, parent, shareWidget),
+      updateIsQueued(false)
+{
+    connect(this, &GLWidgetBase::updateGLLater, this, &GLWidgetBase::updateGLNow, Qt::QueuedConnection);
+}
+
+GLWidgetBase::~GLWidgetBase()
+{
+}
+
+void GLWidgetBase::updateGLNow()
+{
+    // Now, after the area is actually drawn, we should be able to quue the next draws
+    updateIsQueued = false;
+
+    // Call the default updateGL implementation, which will call the paint method
+    QGLWidget::updateGL();
+}
+
+void GLWidgetBase::updateGL()
+{
+    if(updateIsQueued == false)
+    {
+        // Queue the updating the OpenGL Widget
+        updateIsQueued = true;
+        updateGLLater();
+    }
+}

--- a/Sources/glwidgetbase.cpp
+++ b/Sources/glwidgetbase.cpp
@@ -42,14 +42,14 @@ void GLWidgetBase::mouseMoveEvent(QMouseEvent *event)
 {
     int dx = event->x() - lastCursorPos.x();
     int dy = event->y() - lastCursorPos.y();
-    bool bMouseDragged = true;
+    bool wrapMouse = true;
 
-    relativeMouseMoveEvent(dx, dy, &bMouseDragged, event);
+    relativeMouseMoveEvent(dx, dy, &wrapMouse, event);
 
     lastCursorPos = event->pos();
     // mouse looping in view window
 
-    if(bMouseDragged){
+    if(wrapMouse){
         if(event->x() > width()-10){
             lastCursorPos.setX(10);
         }

--- a/Sources/glwidgetbase.cpp
+++ b/Sources/glwidgetbase.cpp
@@ -7,7 +7,6 @@ GLWidgetBase::GLWidgetBase(const QGLFormat& format, QWidget *parent, QGLWidget *
       updateIsQueued(false)
 {
     connect(this, &GLWidgetBase::updateGLLater, this, &GLWidgetBase::updateGLNow, Qt::QueuedConnection);
-    startTimer(0, Qt::VeryCoarseTimer);
 }
 
 GLWidgetBase::~GLWidgetBase()

--- a/Sources/glwidgetbase.cpp
+++ b/Sources/glwidgetbase.cpp
@@ -45,7 +45,9 @@ void GLWidgetBase::mouseMoveEvent(QMouseEvent *event)
 
     relativeMouseMoveEvent(dx, dy, &wrapMouse, event);
 
+#ifndef Q_OS_LINUX
     lastCursorPos = event->pos();
+#endif
     // mouse looping in view window
 
     if(wrapMouse){

--- a/Sources/glwidgetbase.h
+++ b/Sources/glwidgetbase.h
@@ -27,8 +27,10 @@ signals:
 protected:
     virtual void relativeMouseMoveEvent(int dx, int dy, bool* bMouseDragged, Qt::MouseButtons buttons) = 0;
 
-private slots:
+public slots:
     void updateGLNow();
+
+private slots:
     void handleAccumulatedMouseMovement();
 
 private:

--- a/Sources/glwidgetbase.h
+++ b/Sources/glwidgetbase.h
@@ -22,17 +22,26 @@ public:
 
 signals:
     void updateGLLater();
+    void handleAccumulatedMouseMovementLater();
 
 protected:
-    virtual void relativeMouseMoveEvent(int dx, int dy, bool* bMouseDragged, QMouseEvent* Event) = 0;
+    virtual void relativeMouseMoveEvent(int dx, int dy, bool* bMouseDragged, Qt::MouseButtons buttons) = 0;
 
 private slots:
     void updateGLNow();
+    void handleAccumulatedMouseMovement();
 
 private:
+    void handleMovement();
+
     QPoint lastCursorPos;
     bool updateIsQueued;
+    bool mouseUpdateIsQueued;
+    bool blockMouseMovement;
     bool eventLoopStarted;
+
+    int dx, dy;
+    Qt::MouseButtons buttons;
 };
 
 #endif // GLWIDGETBASE_H

--- a/Sources/glwidgetbase.h
+++ b/Sources/glwidgetbase.h
@@ -32,6 +32,7 @@ private slots:
 private:
     QPoint lastCursorPos;
     bool updateIsQueued;
+    bool eventLoopStarted;
 };
 
 #endif // GLWIDGETBASE_H

--- a/Sources/glwidgetbase.h
+++ b/Sources/glwidgetbase.h
@@ -1,0 +1,30 @@
+#ifndef GLWIDGETBASE_H
+#define GLWIDGETBASE_H
+
+#include <QGLWidget>
+
+class GLWidgetBase : public QGLWidget
+{
+    Q_OBJECT
+public:
+    GLWidgetBase(const QGLFormat& format,
+                 QWidget *parent=0,
+                 QGLWidget *shareWidget=0);
+    ~GLWidgetBase();
+
+public:
+    // Instead of updating the opengl area immediatly, this queues drawing and
+    // makes sure, to do it only once until updateGLNow was called.
+    void updateGL() Q_DECL_FINAL Q_DECL_OVERRIDE;
+
+signals:
+    void updateGLLater();
+
+private slots:
+    void updateGLNow();
+
+private:
+    bool updateIsQueued;
+};
+
+#endif // GLWIDGETBASE_H

--- a/Sources/glwidgetbase.h
+++ b/Sources/glwidgetbase.h
@@ -17,13 +17,20 @@ public:
     // makes sure, to do it only once until updateGLNow was called.
     void updateGL() Q_DECL_FINAL Q_DECL_OVERRIDE;
 
+    void mousePressEvent(QMouseEvent *event) Q_DECL_OVERRIDE;
+    void mouseMoveEvent(QMouseEvent *event) Q_DECL_FINAL Q_DECL_OVERRIDE;
+
 signals:
     void updateGLLater();
+
+protected:
+    virtual void relativeMouseMoveEvent(int dx, int dy, bool* bMouseDragged, QMouseEvent* Event) = 0;
 
 private slots:
     void updateGLNow();
 
 private:
+    QPoint lastCursorPos;
     bool updateIsQueued;
 };
 


### PR DESCRIPTION
## Overview

Ok, this a quite a large Pull Request. The basic idea is, that there is now a helper class GLWidgetBase which is used as baseclass for `GLWidget` and `GLImage` to allow integrating workarounds more easily.

This pullrequests solves two issues on Linux:

1. Not responsive Viewport
2. Mouse lags back to origin

Personally I don't like the code-style of my workarounds. So maybe you want to use the workaround only as inspiraton for your final fixes.

## Not responsive Viewport

There's a bug in the propertiary NVidia driver. If your GPU is too powerfull and takes less than a milisecond to draw the image, it can happen, that the whole opengl window totally freezes.  
Normally the solution is to limit the framerate. But as this is not a game with a main loop, this was not an option here. Especially, as the `updateGL` method is called quite ofter during one event queue execution, this would slow down the application extremly.

Instead, my proposed solution is to override the `updateGL` method. It now doesn't paint the image immediatly, but instead queues the draw request exactly once, until the current event loop is done.

The issue however was, that for some reason, the viewport needs to be rendered multiple times before all render-effects look correct. I have no idea why, so I added a workaround to activate the queue after the main event loop is started (indicated by the first mouse movement event).

## Mouse lags back to origin

This is my probosed solution for issue #33 

The problem here was, that the move events on linux are split into multiple small events. For example, if you are moving the mouse by 50 pixels into the right direction, you might end up with 50 events each with offset 1 pixel, instead of one events with 50 pixels at once.

My workaround is quite ugly. It accumulates the small events into one large event, which is more easy to handle. If my workaround is too ugly for your taste, simply ignore the commit f398fdd