### PR TITLE
define GL_MAJOR GL_MINOR to avoid code duplication, do int comparison, ref #28

### DIFF
--- a/Sources/main.cpp
+++ b/Sources/main.cpp
@@ -179,15 +179,13 @@ int main(int argc, char *argv[])
 
     QGLFormat glFormat(QGL::SampleBuffers);
 
-#ifdef Q_OS_MAC
-    glFormat.setProfile( QGLFormat::CoreProfile );
-    glFormat.setVersion( 4, 1 );
-#endif
-
+#if defined(Q_OS_LINUX) || defined(Q_OS_MAC)
 #ifdef USE_OPENGL_330
-#ifdef Q_OS_LINUX
     glFormat.setProfile( QGLFormat::CoreProfile );
     glFormat.setVersion( 3, 3 );
+#else
+    glFormat.setProfile( QGLFormat::CoreProfile );
+    glFormat.setVersion( 4, 1 );
 #endif
 #endif
 


### PR DESCRIPTION
Hi, this pull request defines some GL_MAJOR and GL_MAJOR to avoid code duplication,

Example:

```diff
- #ifdef USE_OPENGL_330
-         msgBox.setInformativeText("Sorry but it seems that your graphics card does not support openGL 3.3.\n"
-                                   "Program will not run :(\n"
-                                   "See " AB_LOG " file for more info.");
- #else
-         msgBox.setInformativeText("Sorry but it seems that your graphics card does not support openGL 4.0.\n"
-                                   "Program will not run :(\n"
-                                   "See " AB_LOG " file for more info.");
- #endif
- 
---
+         msgBox.setInformativeText(QString("Sorry but it seems that your graphics card does not support openGL %1.%2.\n"
+                                           "Program will not run :(\n"
+                                           "See " AB_LOG " file for more info.").arg(GL_MAJOR).arg(GL_MINOR));
```

Also, `glContext->format().majorVersion()` and `glContext->format().minorVersion()` are now called once instead of twice.

``Performance3DSettings::openGLVersion`` still use float (so there is probably still float comparison elsewhere in the code) but it's outside the scope of this pull request.

This PR is based on #49, you can merge #49 first then this one, or just merge this one and close #49.