### PR TITLE
Address segfault in GLWidget::paintGL() due to invalid assignment of …

### DIFF
--- a/Sources/camera.cpp
+++ b/Sources/camera.cpp
@@ -27,7 +27,7 @@ AwesomeCamera::~AwesomeCamera(){
 /**
 *Odnawia pozycje kamery
 */
-QMatrix4x4& AwesomeCamera::updateCamera(void){
+QMatrix4x4 AwesomeCamera::updateCamera(void){
     QMatrix4x4 unit_mat;
     unit_mat.setToIdentity();
     if(isFree){

--- a/Sources/camera.h
+++ b/Sources/camera.h
@@ -22,7 +22,7 @@ public:
     /**
     * Zwraca macierz widoku kamery: ViewMatrix
     */
-    QMatrix4x4& updateCamera(void);
+    QMatrix4x4 updateCamera(void);
     /**
     * Zmienia stan kamery na Free albo zwiazany (WSAD - nie dziala)
     */


### PR DESCRIPTION
Address segfault in GLWidget::paintGL() due to invalid assignment of AwesomeCamera::updateCamera's local variable unit_mat.  Changing method to use pass by value instead of pass by reference.