### PR TITLE
Workaround for OpenGL render failure Linux/Mac bug.

### DIFF
--- a/Sources/main.cpp
+++ b/Sources/main.cpp
@@ -181,7 +181,12 @@ int main(int argc, char *argv[])
     QGLFormat glFormat(QGL::SampleBuffers);
 
 #if defined(Q_OS_LINUX) || defined(Q_OS_MAC)
-    glFormat.setProfile( QGLFormat::CoreProfile );
+     /*
+     * Commenting out the next line because it causes rendering to fail.  QGLFormat::CoreProfile
+     * disables all OpenGL functions that are depreciated as of OpenGL 3.0.  This fix is a workaround.
+     * The full solution is to replace all depreciated OpenGL functions with their current implements.
+    */
+//  glFormat.setProfile( QGLFormat::CoreProfile );
     glFormat.setVersion( GL_MAJOR, GL_MINOR );
 #endif
 


### PR DESCRIPTION
The complete solution is to find and replace all OpenGL 3.0 depreciated function uses.