### PR TITLE
Adding integration with cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,81 @@
+cmake_minimum_required(VERSION 2.6)
+project(awesomebump)
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTOUIC ON)
+
+# This is the default install directory prefix for external resources
+# from the source's Bin/ directory
+# Only used when doing "Release" builds
+set(RESOURCE_DEFAULT lib64/awesomebump)
+
+# Setting the now REQUIRED base directory for resource files in Bin/
+# if a custom path was not provided by the user at compile time
+# This path is referenced in code when loading these resources
+if(NOT RESOURCE_BASE)
+  if(CMAKE_BUILD_TYPE MATCHES "Release")
+    # Default path for "Release" builds
+    # AB must be installed via 'make install' for the program to work
+    set(RESOURCE_BASE ${CMAKE_INSTALL_PREFIX}/${RESOURCE_DEFAULT})
+  else()
+    # "Debug" and other builds will install resources to the same
+    # dir as the executable if no path is provided at compile time
+    # Install is optional; you can just copy Bin/* to the binary's dir
+    # or move the binary to Bin/
+    # Installing via 'make install' will copy the resource files to
+    # the binary's directory for you to make things easier though.
+    set(RESOURCE_BASE ".")
+    install(DIRECTORY Bin/ DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+  endif()
+endif()
+
+# Making sure the required dependencies are present on the build system
+# This list probably needs to be expanded
+find_package(Qt5Core REQUIRED)
+find_package(Qt5Widgets REQUIRED)
+find_package(Qt5OpenGL REQUIRED)
+find_package(Qt5Gui REQUIRED)
+find_package(Qt5DBus REQUIRED)
+find_package(OpenGL REQUIRED)
+
+# Including support for OpenGL 3.3.0
+# Use the option -Drelease_gl330=1 to trigger it
+if(release_gl330)
+  add_definitions(-DUSE_OPENGL_330)
+endif()
+
+# Including source files and setting flags for the build
+add_definitions(${Qt5Widgets_DEFINITIONS} -DRESOURCE_BASE="${RESOURCE_BASE}/")
+qt5_wrap_ui(UI_HEADERS Sources/allaboutdialog.ui Sources/dialogheightcalculator.ui Sources/dialoglogger.ui
+    Sources/dialogshortcuts.ui Sources/formbasemapconversionlevels.ui Sources/formimageprop.ui
+    Sources/formmaterialindicesmanager.ui Sources/formsettingscontainer.ui Sources/formsettingsfield.ui
+    Sources/mainwindow.ui )
+qt5_add_resources(UI_RESOURCES Sources/content.qrc)
+
+set(CMAKE_CXX_FLAGS "${Qt5Widgets_EXECUTABLE_COMPILE_FLAGS}")
+set(AwesomeBump_SRCS
+    Sources/utils/Mesh.cpp Sources/utils/qglbuffers.cpp
+    Sources/utils/tinyobj/tiny_obj_loader.cc Sources/CommonObjects.cpp
+    Sources/allaboutdialog.cpp Sources/camera.cpp Sources/dialogheightcalculator.cpp
+    Sources/camera.cpp Sources/dialogheightcalculator.cpp Sources/camera.cpp
+    Sources/dialogheightcalculator.cpp Sources/camera.cpp
+    Sources/dialogheightcalculator.cpp Sources/dialoglogger.cpp Sources/dialogshortcuts.cpp
+    Sources/dialoglogger.cpp Sources/dialogshortcuts.cpp Sources/formimagebase.cpp
+    Sources/formbasemapconversionlevels.cpp Sources/formimagebase.cpp
+    Sources/formbasemapconversionlevels.cpp Sources/formimageprop.cpp
+    Sources/formmaterialindicesmanager.cpp Sources/formsettingscontainer.cpp
+    Sources/formsettingsfield.cpp Sources/glimageeditor.cpp Sources/glwidget.cpp
+    Sources/glwidgetbase.cpp Sources/mainwindow.cpp Sources/main.cpp) 
+
+# Configure the linker and finalize binary compilation
+add_executable(awesomebump ${AwesomeBump_SRCS} ${UI_HEADERS} ${UI_RESOURCES} Sources/resources/icon.icns)
+target_link_libraries(awesomebump Qt5::Core Qt5::DBus Qt5::Gui Qt5::Widgets Qt5::OpenGL
+    GL icudata icui18n icuuc)
+
+# Create an install target for "Release" builds using custom or default binary and
+# resource file paths
+if(${CMAKE_BUILD_TYPE} MATCHES "Release")
+  install(TARGETS awesomebump RUNTIME DESTINATION bin)
+  install(DIRECTORY Bin/ DESTINATION ${RESOURCE_BASE})
+endif()

--- a/Sources/AwesomeBump.pro
+++ b/Sources/AwesomeBump.pro
@@ -18,6 +18,14 @@ CONFIG(release_gl330) {
     #This is a debug build
 }
 
+# It's now required to define the path for resource files
+# at compile time
+# To keep compatibility with older releases, the application
+# continues to look for these resource files in its current
+# directory's subfolders (Config/* and Core/*) when using
+# qmake to compile
+DEFINES += RESOURCE_BASE=\\\"./\\\"
+
 VPATH += ../shared
 INCLUDEPATH += ../shared include
 

--- a/Sources/formimageprop.cpp
+++ b/Sources/formimageprop.cpp
@@ -771,7 +771,7 @@ void FormImageProp::showGrungeSettingsGroup(){
     //               Loading grunge maps folders
     // ------------------------------------------------------- //
     qDebug() << "Loading cubemaps folders:";
-    QDir currentDir("Core/2D/grunge");
+    QDir currentDir(QString(RESOURCE_BASE) + "Core/2D/grunge");
     currentDir.setFilter(QDir::Files);
     QStringList entries = currentDir.entryList();
     for( QStringList::ConstIterator entry=entries.begin(); entry!=entries.end(); ++entry ){
@@ -809,7 +809,7 @@ void FormImageProp::invertGrunge(bool toggle){
 }
 
 void FormImageProp::loadPredefinedGrunge(QString image){
-    loadFile("Core/2D/grunge/"+image);
+    loadFile(QString(RESOURCE_BASE) + "Core/2D/grunge/image");
 }
 
 void FormImageProp::hideOcclusionInputGroup(){

--- a/Sources/glwidget.cpp
+++ b/Sources/glwidget.cpp
@@ -508,10 +508,10 @@ void GLWidget::initializeGL()
     lightDirection.toggleFreeCamera(false);
     lightDirection.radius = 1;
 
-    mesh        = new Mesh("Core/3D/","Cube.obj");
-    skybox_mesh = new Mesh("Core/3D/","sky_cube.obj");
-    env_mesh    = new Mesh("Core/3D/","sky_cube_env.obj");
-    quad_mesh   = new Mesh("Core/3D/","quad.obj");
+    mesh        = new Mesh(QString(RESOURCE_BASE) + "Core/3D/","Cube.obj");
+    skybox_mesh = new Mesh(QString(RESOURCE_BASE) + "Core/3D/","sky_cube.obj");
+    env_mesh    = new Mesh(QString(RESOURCE_BASE) + "Core/3D/","sky_cube_env.obj");
+    quad_mesh   = new Mesh(QString(RESOURCE_BASE) + "Core/3D/","quad.obj");
 
     m_prefiltered_env_map = new GLTextureCube(512);
 
@@ -1015,7 +1015,7 @@ bool GLWidget::loadMeshFile(const QString &fileName, bool bAddExtension)
     // loading new mesh
     Mesh* new_mesh;
     if(bAddExtension){
-        new_mesh = new Mesh(QString("Core/3D/"),fileName+QString(".obj"));
+      new_mesh = new Mesh(QString(RESOURCE_BASE) + "Core/3D/",fileName+QString(".obj"));
     }else{
         new_mesh = new Mesh(QString(""),fileName);
     }
@@ -1053,9 +1053,8 @@ void GLWidget::chooseMeshFile(const QString &fileName){
 void GLWidget::chooseSkyBox(QString cubeMapName,bool bFirstTime){
     QStringList list;
     makeCurrent();
-    list << "Core/2D/skyboxes/" + cubeMapName + "/posx.jpg" << "Core/2D/skyboxes/" + cubeMapName  + "/negx.jpg" << "Core/2D/skyboxes/" + cubeMapName + "/posy.jpg"
-         << "Core/2D/skyboxes/" + cubeMapName + "/negy.jpg" << "Core/2D/skyboxes/" + cubeMapName  + "/posz.jpg" << "Core/2D/skyboxes/" + cubeMapName + "/negz.jpg";
-
+    list << QString(RESOURCE_BASE) + "Core/2D/skyboxes/" + cubeMapName + "/posx.jpg" << QString(RESOURCE_BASE) + "Core/2D/skyboxes/" + cubeMapName  + "/negx.jpg" << QString(RESOURCE_BASE) + "Core/2D/skyboxes/" + cubeMapName + "/posy.jpg"
+         << QString(RESOURCE_BASE) + "Core/2D/skyboxes/" + cubeMapName + "/negy.jpg" << QString(RESOURCE_BASE) + "Core/2D/skyboxes/" + cubeMapName  + "/posz.jpg" << QString(RESOURCE_BASE) + "Core/2D/skyboxes/" + cubeMapName + "/negz.jpg";
 
     qDebug() << "Reading new cube map:" << list;
     bDiffuseMapBaked     = false;

--- a/Sources/mainwindow.cpp
+++ b/Sources/mainwindow.cpp
@@ -515,7 +515,7 @@ MainWindow::MainWindow(QWidget *parent) :
     //               Loading cub maps folders
     // ------------------------------------------------------- //
     qDebug() << "Loading cubemaps folders:";
-    QDir currentDir(_find_data_dir("Core/2D/skyboxes"));
+    QDir currentDir(_find_data_dir(QString(RESOURCE_BASE) + "Core/2D/skyboxes"));
     currentDir.setFilter(QDir::Dirs);
     QStringList entries = currentDir.entryList();
     for( QStringList::ConstIterator entry=entries.begin(); entry!=entries.end(); ++entry ){


### PR DESCRIPTION
Adds integration with cmake.  qmake is still supported and works exactly the same as it did before.  Also, additional changes were made to create install targets and custom resource file paths.  I have tested extensively but let me know if there are any issues.

The following flags have special meaning:
-DCMAKE_BUILD_TYPE=Release
Will do a Release build.  `make install` is required afterwards for the program to function.

-Drelease_gl330=1
Enables OpenGL 3.3.0 support.

-DRESOURCE_BASE=\<path\>
Optional path (absolute or relative) to place resource files when installing via `make install`.  Defaults to `/usr/local/lib64/awesomebump` when doing a Release build.  Defaults to the binary's build directory for all other build types.

-DCMAKE_INSTALL_PREFIX=\<path\>
Optional path prefix for installing the binary and resource files when doing `make install`.

For convenience when doing a non-Release build, 'make install' will copy all of the resource files from Bin/ to the binary's build directory for you.  This isn't required though, and you can optionally copy the binary to the resource directory (Bin/) as before this commit or copy the resource files (Bin/*) to the build directory.
Here's the preferred way to use this:
```
cd <AB-source-dir>
mkdir build
cd build
cmake [options] ..
make
make install
```
Don't forget the `..` after `cmake [options]`!

This has not been tested on Windows.