### PR TITLE
Account for how qt6 & qmake-qt5 coexist & check vars.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,4 @@ build-*
 workdir
 /Sources/main.moc
 /Sources/moc_*
+/Bin/AwesomeBump.desktop

--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,5 @@ Sources/AwesomeBump.pro.user.1ac2611
 
 build-*
 workdir
+/Sources/main.moc
+/Sources/moc_*

--- a/unixBuildScript.sh
+++ b/unixBuildScript.sh
@@ -3,11 +3,28 @@
 # Add your QT path here by setting MY_QT_PATH variable
 # MY_QT_PATH=/YOUR_PATH_HERE/Qt/5.X/gcc_64/bin
 # MY_QT_PATH=/opt/Qt5.9.0/5.9/gcc_64/bin
+_QMAKE_PATH=`which qmake-qt5`
+
 if [ "x$MY_QT_PATH" = "x" ]; then
+    # It was not set using `export MY_QT_PATH` before running this script,
+    #   so use the default:
     MY_QT_PATH=/usr/bin
+    # ...or detected path if present:
+    if [ -f "$_QMAKE_PATH" ]; then
+        # Get the parent directory path only:
+        MY_QT_PATH="`dirname $_QMAKE_PATH`"
+    fi
 fi
+
 if [ "x$MY_QMAKE" = "x" ]; then
+    # It was not set using `export MY_QMAKE` before running this script,
+    #   so use the default:
     MY_QMAKE=qmake-qt5
+    # ...or detected path if present:
+    if [ -f "$_QMAKE_PATH" ]; then
+        # Get the filename only (not path):
+        MY_QMAKE="`basename $_QMAKE_PATH`"
+    fi
 fi
 _DO_INSTALL=false
 for var in "$@"

--- a/unixBuildScript.sh
+++ b/unixBuildScript.sh
@@ -9,20 +9,30 @@ fi
 if [ "x$MY_QMAKE" = "x" ]; then
     MY_QMAKE=qmake-qt5
 fi
+me="`basename $0`"
 if [ ! -f "$MY_QT_PATH/$MY_QMAKE" ]; then
     >&2 cat <<END
+
 Error: $MY_QT_PATH/$MY_QMAKE doesn't exist. Change MY_QT_PATH to the
 directory containing qmake-qt5 and if you don't want to use qmake-qt5
-change MY_QMAKE to the path relative to MY_QT_PATH.
+change MY_QMAKE to the path relative to MY_QT_PATH, then
+run:
+
+    export MY_QT_PATH
+    export MY_QMAKE
+    ./$me
+
+...or if you don't have qmake-qt5,
 END
     if [ -f "`command -v dnf`" ]; then
         >&2 cat <<END
-sudo dnf install -y qtbase5-dev qt5-qtscript-dev
+first install the following rpm packages:
+    sudo dnf install -y qt5-qtbase-devel qt5-qtscript-devel
 END
     else
         >&2 cat <<END
-Try installing the following packages:
-qt5-qtbase-devel qt5-qtscript-devel
+try installing the following deb packages:
+    qtbase5-dev qt5-qtscript-dev
 END
     fi
     exit 1

--- a/unixBuildScript.sh
+++ b/unixBuildScript.sh
@@ -3,28 +3,40 @@
 # Add your QT path here by setting MY_QT_PATH variable
 # MY_QT_PATH=/YOUR_PATH_HERE/Qt/5.X/gcc_64/bin
 # MY_QT_PATH=/opt/Qt5.9.0/5.9/gcc_64/bin
-_QMAKE_PATH=`which qmake-qt5`
+_SYSTEM_QMAKE=`which qmake-qt5`
 
 if [ "x$MY_QT_PATH" = "x" ]; then
+    >&2 echo "MY_QT_PATH was not set..."
     # It was not set using `export MY_QT_PATH` before running this script,
     #   so use the default:
     MY_QT_PATH=/usr/bin
     # ...or detected path if present:
-    if [ -f "$_QMAKE_PATH" ]; then
+    if [ -f "$_SYSTEM_QMAKE" ]; then
         # Get the parent directory path only:
-        MY_QT_PATH="`dirname $_QMAKE_PATH`"
+        MY_QT_PATH="`dirname $_SYSTEM_QMAKE`"
+        echo "MY_QT_PATH=$MY_QT_PATH (detected `basename $_SYSTEM_QMAKE` in the PATH)"
+    else
+        echo "MY_QT_PATH=$MY_QT_PATH (default)"
     fi
+else
+    echo "MY_QT_PATH=$MY_QT_PATH (was set in environment)"
 fi
 
 if [ "x$MY_QMAKE" = "x" ]; then
+    >&2 echo "MY_QMAKE was not set..."
     # It was not set using `export MY_QMAKE` before running this script,
     #   so use the default:
     MY_QMAKE=qmake-qt5
     # ...or detected path if present:
-    if [ -f "$_QMAKE_PATH" ]; then
+    if [ -f "$_SYSTEM_QMAKE" ]; then
         # Get the filename only (not path):
-        MY_QMAKE="`basename $_QMAKE_PATH`"
+        MY_QMAKE="`basename $_SYSTEM_QMAKE`"
+        echo "MY_QMAKE=$MY_QMAKE (detected `basename $_SYSTEM_QMAKE` in the PATH)"
+    else
+        echo "MY_QMAKE=$MY_QMAKE (default)"
     fi
+else
+    echo "MY_QMAKE=$MY_QMAKE (was set in environment)"
 fi
 _DO_INSTALL=false
 for var in "$@"
@@ -74,7 +86,6 @@ Path="`pwd`/Bin"
 SC_NAME=AwesomeBump.desktop
 SC_TMP="$Path/$SC_NAME"
 # ^ use SC_NAME since that is also used to detect the destination.
-
 
 BUILD_WITH_OPENGL_330_SUPPORT=$1
 

--- a/unixBuildScript.sh
+++ b/unixBuildScript.sh
@@ -1,8 +1,32 @@
 #!/bin/bash
 
 # Add your QT path here by setting MY_QT_PATH variable
-# MY_QT_PATH=/YOUR_PATH_HERE/Qt/5.X/gcc_64/bin/
-MY_QT_PATH=/opt/Qt5.9.0/5.9/gcc_64/bin/
+# MY_QT_PATH=/YOUR_PATH_HERE/Qt/5.X/gcc_64/bin
+# MY_QT_PATH=/opt/Qt5.9.0/5.9/gcc_64/bin
+if [ "x$MY_QT_PATH" = "x" ]; then
+    MY_QT_PATH=/usr/bin
+fi
+if [ "x$MY_QMAKE" = "x" ]; then
+    MY_QMAKE=qmake-qt5
+fi
+if [ ! -f "$MY_QT_PATH/$MY_QMAKE" ]; then
+    >&2 cat <<END
+Error: $MY_QT_PATH/$MY_QMAKE doesn't exist. Change MY_QT_PATH to the
+directory containing qmake-qt5 and if you don't want to use qmake-qt5
+change MY_QMAKE to the path relative to MY_QT_PATH.
+END
+    if [ -f "`command -v dnf`" ]; then
+        >&2 cat <<END
+sudo dnf install -y qtbase5-dev qt5-qtscript-dev
+END
+    else
+        >&2 cat <<END
+Try installing the following packages:
+qt5-qtbase-devel qt5-qtscript-devel
+END
+    fi
+    exit 1
+fi
 BUILD_WITH_OPENGL_330_SUPPORT=$1
 
 MAKE_NUM_THREADS='-j 8'
@@ -29,7 +53,7 @@ if [ ! -e "$MY_QT_PATH" ]; then
 	echo " ---------------------------------"
 	echo "      Error: Wrong Qt path."
 	echo " ---------------------------------"
-	echo " Qt not found at '$MY_QT_PATH'."	
+	echo " Qt not found at '$MY_QT_PATH'."
 	echo " Please set the MY_QT_PATH variable in the ./unixBuildScript.sh"
 	echo ""
 	exit 1
@@ -43,9 +67,9 @@ else
     cd Sources/utils/QtnProperty
     $wget https://github.com/kmkolasinski/QtnProperty/archive/master.zip
     unzip master.zip
-    rm master.zip 
+    rm master.zip
     mv QtnProperty-master/* .
-    rm -r QtnProperty-master    
+    rm -r QtnProperty-master
     cd ../../../
 fi
 
@@ -53,7 +77,7 @@ rm .qmake.stash
 rm Makefile
 rm Sources/Makefile
 
-${MY_QT_PATH}/qmake ./AwesomeBump.pro ${QMAKE_CONFIG} \
+${MY_QT_PATH}/$MY_QMAKE ./AwesomeBump.pro ${QMAKE_CONFIG} \
     && make clean && make $MAKE_NUM_THREADS \
 	&& echo "*** Copying binary from `cat workdir/current` ..." \
 	&& cp -vr workdir/`cat workdir/current`/bin/AwesomeBump$exe ./Bin/AwesomeBump$APP_SUFFIX$exe


### PR DESCRIPTION
qmake is called qmake-qt5 now, so this change will make the script work on more systems. It also allows people to set the name using MY_QMAKE, and now this script no longer overwrites the MY_QT_PATH if the user has done export MY_QT_PATH before running this script. It also fixes an error in the script where the default MY_QT_PATH ended with `/` and the resulting path had two slashes.